### PR TITLE
Fix ratings stars content direction

### DIFF
--- a/app/checkout/[rideId]/index.tsx
+++ b/app/checkout/[rideId]/index.tsx
@@ -197,6 +197,7 @@ export default function Checkout() {
                     </Text>
                     <StarRating
                       size={28}
+                      justifyContent="flex-start"
                       onRatingChange={(rating) => {
                         setRatings((prevRatings) => {
                           // Remove existing rating for this user if it exists

--- a/app/ratings/star-rating.tsx
+++ b/app/ratings/star-rating.tsx
@@ -9,6 +9,7 @@ interface StarRatingProps {
   maxRating?: number
   userId?: string
   size?: number
+  justifyContent?: 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around'
 }
 
 export default function StarRating({
@@ -17,6 +18,7 @@ export default function StarRating({
   maxRating = 5,
   userId,
   size = 30,
+  justifyContent = 'center',
 }: StarRatingProps) {
   const [rating, setRating] = useState(initialRating)
 
@@ -44,7 +46,7 @@ export default function StarRating({
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { justifyContent }]}>
       {Array.from({ length: maxRating }, (_, index) => renderStar(index))}
     </View>
   )
@@ -54,7 +56,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'row',
-    // justifyContent: 'center',
     alignItems: 'center',
     gap: 5,
     borderRadius: 10,


### PR DESCRIPTION
Add `justifyContent` prop to `StarRating` component to allow configurable alignment, resolving CARPIL-77.

---
Linear Issue: [CARPIL-77](https://linear.app/carpil/issue/CARPIL-77/adjust-ratings-stars-content-direction)

<a href="https://cursor.com/background-agent?bcId=bc-25131203-b2c7-4e44-b4ca-cd15d3d67f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25131203-b2c7-4e44-b4ca-cd15d3d67f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

