### PR TITLE
Update button label in rating flow

### DIFF
--- a/app/ratings/driver-rating.tsx
+++ b/app/ratings/driver-rating.tsx
@@ -11,12 +11,14 @@ interface DriverRatingProps {
   user: UserInfo
   onNext?: () => void
   onSaveRating: (rating: Rating) => void
+  hasOtherPassengers?: boolean
 }
 
 export default function DriverRating({
   user,
   onNext,
   onSaveRating,
+  hasOtherPassengers = false,
 }: DriverRatingProps) {
   const [rating, setRating] = useState(0)
 
@@ -50,7 +52,9 @@ export default function DriverRating({
           onNext?.()
         }}
       >
-        <Text style={styles.completeButtonText}>Siguiente</Text>
+        <Text style={styles.completeButtonText}>
+          {hasOtherPassengers ? 'Siguiente' : 'Finalizar'}
+        </Text>
       </TouchableOpacity>
     </View>
   )

--- a/app/ratings/modal.tsx
+++ b/app/ratings/modal.tsx
@@ -126,6 +126,7 @@ export default function RatingsModal({ pendingReviews }: RatingsModalProps) {
             user={driver}
             onNext={handleNext}
             onSaveRating={handleSaveRating}
+            hasOtherPassengers={passengers.length > 0}
           />
         )}
         {currentStep === 2 && passengers.length > 0 && (


### PR DESCRIPTION
Change the driver rating button label from 'Siguiente' to 'Finalizar' when there are no other passengers to rate.

This resolves Linear issue CARPIL-78 by ensuring the button text correctly indicates the end of the rating flow when no further passenger ratings are pending.

---
Linear Issue: [CARPIL-78](https://linear.app/carpil/issue/CARPIL-78/change-label-from-siguiente-to-finalizar)

<a href="https://cursor.com/background-agent?bcId=bc-f7e29fc4-e232-43b2-95ae-7fd1f3cb56d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7e29fc4-e232-43b2-95ae-7fd1f3cb56d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

