### PR TITLE
Fix ride navigation after driver starts ride

### DIFF
--- a/app/ride/[id].tsx
+++ b/app/ride/[id].tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   ActivityIndicator,
 } from 'react-native'
-import { Stack, useLocalSearchParams } from 'expo-router'
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
 import Screen from '@components/screen'
 import Avatar from '@components/avatar'
 import { formatDate } from '@utils/format-date'
@@ -21,6 +21,7 @@ export default function RideDetails() {
   const rideId = id as string
   const { ride, loading, error } = useRealtimeRide(rideId)
   const { calculateDriver } = useDriver()
+  const router = useRouter()
 
   if (loading) {
     return (
@@ -101,8 +102,15 @@ export default function RideDetails() {
   }
 
   const handleStartRide = async () => {
-    const message = await startRide(rideId)
-    console.log({ message })
+    try {
+      const message = await startRide(rideId)
+      console.log({ message })
+      if (message) {
+        router.push(`/ride-navigation/${rideId}`)
+      }
+    } catch (error) {
+      console.error('Error starting ride:', error)
+    }
   }
 
   return (


### PR DESCRIPTION
Add navigation to `ride-navigation/[rideId]` after the driver starts the ride to resolve CARPIL-65.

---
Linear Issue: [CARPIL-65](https://linear.app/carpil/issue/CARPIL-65/go-to-ride-navigationrideid-after-driver-starts-the-ride)

<a href="https://cursor.com/background-agent?bcId=bc-c816ed67-dfe1-464e-9723-53735e459411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c816ed67-dfe1-464e-9723-53735e459411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

