### PR TITLE
Adjust mapview to current route

### DIFF
--- a/app/ride-navigation/[rideId].tsx
+++ b/app/ride-navigation/[rideId].tsx
@@ -59,6 +59,22 @@ export default function RideNavigationScreen() {
     fetchRide()
   }, [rideId])
 
+  useEffect(() => {
+    if (ride && mapRef.current && origin && destination) {
+      // Fit map to show the entire route
+      mapRef.current.fitToCoordinates(
+        [
+          { latitude: origin.lat!, longitude: origin.lng! },
+          { latitude: destination.lat!, longitude: destination.lng! },
+        ],
+        {
+          edgePadding: { top: 100, right: 50, bottom: 300, left: 50 },
+          animated: true,
+        }
+      )
+    }
+  }, [ride, origin, destination])
+
   if (ride == null || ride.origin == null || ride.destination == null) {
     return null
   }


### PR DESCRIPTION
Adjust MapView to automatically fit the current route between origin and destination.

Previously, the map used a fixed initial region, which did not dynamically show the actual ride route. This change improves the user experience by ensuring the full route is visible upon loading the ride navigation screen.

---
Linear Issue: [CARPIL-70](https://linear.app/carpil/issue/CARPIL-70/adjust-mapview-to-current-route)

<a href="https://cursor.com/background-agent?bcId=bc-5656dd43-5276-45f0-9354-0b7715896190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5656dd43-5276-45f0-9354-0b7715896190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

