### PR TITLE
feat: Seamless checkout to ratings modal flow

### DIFF
--- a/app/checkout/[rideId]/sinpe-movil.tsx
+++ b/app/checkout/[rideId]/sinpe-movil.tsx
@@ -13,7 +13,7 @@ import { COLORS } from '@utils/constansts/colors'
 import { useEffect, useState } from 'react'
 import { getRide } from 'services/api/rides'
 import { Ride } from '~types/ride'
-import { getUser } from 'services/api/user'
+import { getUser, bootstrapMe } from 'services/api/user'
 import { useAuthStore } from 'store/useAuthStore'
 import { User } from '~types/user'
 import Avatar from '@components/avatar'
@@ -21,6 +21,7 @@ import { formatCRC } from '@utils/currency'
 import * as ImagePicker from 'expo-image-picker'
 import { uploadReceiptToStorage } from 'services/firestore/upload-receipt'
 import { completeSinpePayment } from 'services/api/payments'
+import { useBootstrapStore } from 'store/useBootstrapStore'
 
 export default function SinpeMovilPayment() {
   const { rideId } = useLocalSearchParams<{ rideId: string }>()
@@ -32,6 +33,7 @@ export default function SinpeMovilPayment() {
   const [isProcessing, setIsProcessing] = useState(false)
 
   const { token, user } = useAuthStore((state) => state)
+  const setBootstrap = useBootstrapStore((state) => state.setBootstrap)
 
   useEffect(() => {
     const fetchRide = async () => {
@@ -123,6 +125,12 @@ export default function SinpeMovilPayment() {
           'No se pudo completar el pago. Intenta nuevamente.',
         )
         return
+      }
+
+      // Refresh bootstrap data to trigger modal switch
+      const bootstrap = await bootstrapMe()
+      if (bootstrap) {
+        setBootstrap(bootstrap)
       }
 
       Alert.alert('¡Éxito!', 'Tu pago ha sido registrado exitosamente.', [


### PR DESCRIPTION
## Summary

- Implemented seamless modal transition from checkout to ratings after payment completion
- Both debit card and SINPE Móvil payment methods now refresh bootstrap data after successful payment
- Checkout modal automatically closes and ratings modal automatically opens without page refresh
- Fixed button text in driver rating to show "Finalizar" when there are no other passengers to rate
- Added justifyContent prop to StarRating component for better layout control
- Removed unused passenger rating display from ride navigation screen

## Changes

### Checkout Modal Flow
- **CheckoutModal**: Added bootstrap refresh after successful debit card payment
- **SinpeMovilPayment**: Added bootstrap refresh after successful SINPE payment
- After payment success, the app now:
  1. Refreshes bootstrap data from API
  2. Updates the store (clears `pendingPayment`, populates `pendingReviews`)
  3. Closes checkout modal automatically
  4. Opens ratings modal automatically

### Rating Improvements
- **DriverRating**: Dynamic button text based on whether there are other passengers
- **StarRating**: Added `justifyContent` prop for flexible layout alignment
- **RideNavigation**: Cleaned up unused rating display code

## Test Plan

- [ ] Complete debit card payment and verify ratings modal opens
- [ ] Complete SINPE Móvil payment and verify ratings modal opens
- [ ] Verify no page refresh occurs during modal transition
- [ ] Test driver rating button shows correct text ("Finalizar" vs "Siguiente")
- [ ] Verify StarRating component layout with new justifyContent prop