### PR TITLE
Fix safe screen padding on tabbed screens

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -17,7 +17,7 @@ export default function Profile() {
   }
 
   return (
-    <SafeScreen>
+    <SafeScreen applyTopInset={false}>
       <Text>{user?.id}</Text>
       <Text>{user?.name}</Text>
       <Text>{user?.email}</Text>

--- a/app/chats/index.tsx
+++ b/app/chats/index.tsx
@@ -34,7 +34,7 @@ export default function Chats() {
 
   if (loading) {
     return (
-      <SafeScreen backgroundColor={COLORS.dark_gray}>
+      <SafeScreen backgroundColor={COLORS.dark_gray} applyTopInset={false}>
         <View style={styles.container}>
           <View style={styles.header}>
             <Text style={styles.headerText}>Chats</Text>
@@ -52,7 +52,7 @@ export default function Chats() {
   }
 
   return (
-    <SafeScreen backgroundColor={COLORS.dark_gray}>
+    <SafeScreen backgroundColor={COLORS.dark_gray} applyTopInset={false}>
       <View style={styles.container}>
         <FlatList
           data={chats}

--- a/app/ride/index.tsx
+++ b/app/ride/index.tsx
@@ -115,7 +115,7 @@ export default function Rides() {
 
   if (loading) {
     return (
-      <SafeScreen>
+      <SafeScreen applyTopInset={false}>
         <FlatList
           data={Array.from({ length: 5 })}
           renderItem={() => <RideCardSkeleton />}
@@ -128,7 +128,7 @@ export default function Rides() {
   }
 
   return (
-    <SafeScreen>
+    <SafeScreen applyTopInset={false}>
       <FlatList
         data={rides}
         renderItem={renderItem}
@@ -148,7 +148,7 @@ export default function Rides() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{
           flexGrow: 1,
-          paddingBottom: 100, // Space for CreateRideButton
+          paddingBottom: 100,
         }}
       />
       <CreateRideButton />

--- a/components/safe-screen.tsx
+++ b/components/safe-screen.tsx
@@ -1,32 +1,41 @@
 import { View, StyleSheet, Platform } from 'react-native'
-import {
-  SafeAreaProvider,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { COLORS } from '@utils/constansts/colors'
 
 interface Props {
   backgroundColor?: string
   children: React.ReactNode
+  applyTopInset?: boolean
+  applyBottomInset?: boolean
 }
 
 export default function SafeScreen({
   backgroundColor = COLORS.primary,
   children,
+  applyTopInset = true,
+  applyBottomInset = false,
 }: Props) {
   const insets = useSafeAreaInsets()
+  
+  const paddingTop = applyTopInset 
+    ? (Platform.OS === 'ios' ? insets.top : 0) + 16 
+    : 16
+  
+  const paddingBottom = applyBottomInset 
+    ? insets.bottom 
+    : 0
+
   return (
-    <SafeAreaProvider>
-      <View
-        style={{
-          ...styles.container,
-          backgroundColor,
-          paddingTop: (Platform.OS === 'ios' ? insets.top : 0) + 16,
-        }}
-      >
-        {children}
-      </View>
-    </SafeAreaProvider>
+    <View
+      style={{
+        ...styles.container,
+        backgroundColor,
+        paddingTop,
+        paddingBottom,
+      }}
+    >
+      {children}
+    </View>
   )
 }
 


### PR DESCRIPTION
Fix SafeScreen padding issues in tab screens by making it configurable and removing a redundant `SafeAreaProvider`.

The `SafeScreen` component was causing unnecessary bottom padding in tab screens because it always applied top insets, conflicting with tab screens' custom headers, and didn't account for the tab bar. This PR introduces `applyTopInset` and `applyBottomInset` props to `SafeScreen` for flexible control, and tab screens now explicitly disable `applyTopInset`. The nested `SafeAreaProvider` within `SafeScreen` was also removed as it's meant to be at the root.

---
Linear Issue: [CARPIL-89](https://linear.app/carpil/issue/CARPIL-89/safe-screen-broken-in-some-screens)

<a href="https://cursor.com/background-agent?bcId=bc-3766c434-4ff6-43fb-9da1-3e8b001a05a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3766c434-4ff6-43fb-9da1-3e8b001a05a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

