### PR TITLE
Fix ios notification back navigation fallback

### DIFF
--- a/app/chats/_layout.tsx
+++ b/app/chats/_layout.tsx
@@ -26,7 +26,7 @@ export default function ChatsLayout() {
         name="messages"
         options={{
           headerShown: true,
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
     </Stack>

--- a/app/create-ride/_layout.tsx
+++ b/app/create-ride/_layout.tsx
@@ -28,7 +28,7 @@ export default function CreateRideLayout() {
         options={{
           title: 'Selecciona tu origen',
           headerShown: true,
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
       <Stack.Screen
@@ -36,7 +36,7 @@ export default function CreateRideLayout() {
         options={{
           title: 'Selecciona tu destino',
           headerShown: true,
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
       <Stack.Screen
@@ -44,7 +44,7 @@ export default function CreateRideLayout() {
         options={{
           title: 'Punto de encuentro',
           headerShown: true,
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
       <Stack.Screen
@@ -56,7 +56,7 @@ export default function CreateRideLayout() {
           },
           headerTransparent: true,
           headerShown: true,
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
           headerRight: () => (
             <CloseButton onPress={() => router.replace('/(tabs)')} />
           ),

--- a/app/login/_layout.tsx
+++ b/app/login/_layout.tsx
@@ -26,7 +26,7 @@ export default function LoginLayout() {
         name="login-email"
         options={{
           title: 'Iniciar sesión',
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
     </Stack>

--- a/app/ride/_layout.tsx
+++ b/app/ride/_layout.tsx
@@ -26,7 +26,7 @@ export default function RideLayout() {
             backgroundColor: COLORS.primary,
           },
           headerTitle: 'Detalles del ride',
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
     </Stack>

--- a/app/signup/_layout.tsx
+++ b/app/signup/_layout.tsx
@@ -20,7 +20,7 @@ export default function SignUpLayout() {
         name="index"
         options={{
           title: 'Registrarse',
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
         }}
       />
     </Stack>

--- a/app/users/[userId].tsx
+++ b/app/users/[userId].tsx
@@ -65,7 +65,7 @@ export default function UserDetails() {
           },
           headerShadowVisible: false,
           headerTitle: 'Detalles del usuario',
-          headerLeft: () => <BackButton onPress={() => router.back()} />,
+          headerLeft: () => <BackButton />,
           headerBackVisible: false,
         }}
       />

--- a/components/buttons/header-back.tsx
+++ b/components/buttons/header-back.tsx
@@ -6,9 +6,19 @@ import { useRouter } from 'expo-router'
 export default function HeaderBack() {
   const router = useRouter()
 
+  const handleBack = () => {
+    // Check if we can navigate back in the stack
+    if (router.canGoBack()) {
+      router.back()
+    } else {
+      // Fallback to home tab when coming from notifications on iOS
+      router.replace('/(tabs)/')
+    }
+  }
+
   return (
     <TouchableOpacity
-      onPress={() => router.back()}
+      onPress={handleBack}
       style={{
         marginLeft: 2,
         padding: 4,

--- a/components/design-system/buttons/back-button.tsx
+++ b/components/design-system/buttons/back-button.tsx
@@ -4,10 +4,21 @@ import { COLORS } from '@utils/constansts/colors'
 import { router } from 'expo-router'
 
 interface BackButtonProps {
-  onPress: () => void
+  onPress?: () => void
 }
+
+const handleBackNavigation = () => {
+  // Check if we can navigate back in the stack
+  if (router.canGoBack()) {
+    router.back()
+  } else {
+    // Fallback to home tab when coming from notifications on iOS
+    router.replace('/(tabs)/')
+  }
+}
+
 export default function BackButton({
-  onPress = () => router.back(),
+  onPress = handleBackNavigation,
 }: BackButtonProps) {
   if (Platform.OS === 'ios') {
     return (

--- a/services/push-notifications/handle-notification-navigation.ts
+++ b/services/push-notifications/handle-notification-navigation.ts
@@ -25,7 +25,10 @@ export const handleNotificationNavigation = (data: NotificationData) => {
     const path = url.replace(/^carpil:\/\//, '/')
 
     console.log(`🧭 Navigating to: ${path}`)
-    router.push(path as any)
+    
+    // Use replace instead of push to avoid navigation stack issues on iOS
+    // This ensures the home tab is in the navigation stack as a fallback
+    router.replace(path as any)
   } catch (error) {
     console.error('❌ Error handling notification navigation:', error)
   }


### PR DESCRIPTION
Add a fallback to the home tab for back navigation from screens opened via push notifications.

This resolves an iOS warning where attempting to go back from a screen opened directly from a push notification would fail due to an empty navigation stack. The fix involves using `router.replace()` for notification navigation and implementing a `router.canGoBack()` check in back button components to navigate to the home tab if no previous screen exists.

---
Linear Issue: [CARPIL-90](https://linear.app/carpil/issue/CARPIL-90/handle-go-back-from-notification-in-ios-devices)

<a href="https://cursor.com/background-agent?bcId=bc-24169979-174e-4072-bc7c-55aa3403c15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24169979-174e-4072-bc7c-55aa3403c15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

