### PR TITLE
Fix navbar text from Index to Rides

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -50,6 +50,7 @@ export default function TabsLayout() {
         <Tabs.Screen
           name="index"
           options={{
+            tabBarLabel: 'Rides',
             tabBarIcon: ({ color }) => <CarIcon color={color} />,
             headerShown: true,
             header: () => (


### PR DESCRIPTION
Update tab bar label from 'Index' to 'Rides' to resolve CARPIL-92.

---
Linear Issue: [CARPIL-92](https://linear.app/carpil/issue/CARPIL-92/navbar-says-index-instead-of-rides)

<a href="https://cursor.com/background-agent?bcId=bc-95d91ea5-fa42-489d-b0e5-c3e74d1a984e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95d91ea5-fa42-489d-b0e5-c3e74d1a984e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

