### PR TITLE
Implement unjoin ride functionality

### DIFF
--- a/app/ride/[id].tsx
+++ b/app/ride/[id].tsx
@@ -10,10 +10,11 @@ import Screen from '@components/screen'
 import Avatar from '@components/avatar'
 import { formatDate } from '@utils/format-date'
 import { COLORS } from '@utils/constansts/colors'
-import { joinRide, startRide } from 'services/api/rides'
+import { joinRide, startRide, unjoinRide } from 'services/api/rides'
 import { useRealtimeRide } from 'hooks/useRealtimeRide'
 import { useDriver } from 'hooks/useDriver'
 import ActionButton from '@components/design-system/buttons/action-button'
+import { useAuthStore } from 'store/useAuthStore'
 
 export default function RideDetails() {
   const { id } = useLocalSearchParams()
@@ -21,6 +22,7 @@ export default function RideDetails() {
   const { ride, loading, error } = useRealtimeRide(rideId)
   const { calculateDriver } = useDriver()
   const router = useRouter()
+  const { user } = useAuthStore()
 
   if (loading) {
     return (
@@ -59,6 +61,7 @@ export default function RideDetails() {
   } = ride
 
   const isDriver = calculateDriver(driver.id)
+  const isPassenger = user ? passengers.some((p) => p.id === user.id) : false
 
   const remainingSeats = availableSeats - passengers.length
   const fullSeats = availableSeats === passengers.length
@@ -75,6 +78,19 @@ export default function RideDetails() {
       }
     } catch (error) {
       console.error('Error joining ride:', error)
+    }
+  }
+
+  const handleUnjoinRide = async () => {
+    try {
+      const message = await unjoinRide(rideId)
+      if (message) {
+        console.log('Successfully unjoined ride:', message)
+      } else {
+        console.log('Failed to unjoin ride')
+      }
+    } catch (error) {
+      console.error('Error unjoining ride:', error)
     }
   }
 
@@ -168,6 +184,12 @@ export default function RideDetails() {
           <ActionButton
             onPress={handleStartRide}
             text="Iniciar viaje"
+            type="secondary"
+          />
+        ) : isPassenger ? (
+          <ActionButton
+            onPress={handleUnjoinRide}
+            text="Cancelar espacio"
             type="secondary"
           />
         ) : (

--- a/services/api/rides.ts
+++ b/services/api/rides.ts
@@ -99,6 +99,28 @@ export const joinRide = async (id: string) => {
   return message
 }
 
+export const unjoinRide = async (id: string) => {
+  const token = useAuthStore.getState().token
+  const response = await fetch(`${API_URL}/rides/${id}/un-join`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    console.log({ status: response.status, error })
+    return null
+  }
+
+  const data = (await response.json()) as DefaultResponse
+  const { message } = data
+
+  return message
+}
+
 export const startRide = async (id: string) => {
   const token = useAuthStore.getState().token
   const response = await fetch(`${API_URL}/rides/${id}/start`, {


### PR DESCRIPTION
Implement "unjoin ride" functionality and dynamically display a "Cancel space" button to allow passengers to leave a ride.

This fixes a bug (CARPIL-72) where the "Reserve space" button was always shown, even if the user had already joined the ride.

---
Linear Issue: [CARPIL-72](https://linear.app/carpil/issue/CARPIL-72/un-join-the-ride)

<a href="https://cursor.com/background-agent?bcId=bc-5d546a4d-0346-4e37-950c-f1501ab8cfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d546a4d-0346-4e37-950c-f1501ab8cfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

