### PR TITLE
Places autocomplete spacing bug

### DIFF
--- a/components/places-autocomplete.tsx
+++ b/components/places-autocomplete.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react-native-google-places-autocomplete'
 import { Location } from '~types/location'
 import { COLORS } from '@utils/constansts/colors'
+import { logger } from '@utils/logs'
 
 const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY ?? ''
 
@@ -53,6 +54,14 @@ export default function PlacesAutocomplete({
   onPress,
   onFail,
 }: Props) {
+  const handleFail = (error: any) => {
+    logger.error('Google Places Autocomplete failed', {
+      action: 'places_autocomplete_failed',
+      metadata: { error: error?.message || 'Unknown error', queryType },
+    })
+    onFail?.(error)
+  }
+
   return (
     <GooglePlacesAutocomplete
       fetchDetails
@@ -84,8 +93,14 @@ export default function PlacesAutocomplete({
         }
         onPress(location)
       }}
-      onFail={onFail}
+      onFail={handleFail}
       styles={{
+        container: {
+          flex: 0,
+        },
+        listView: {
+          backgroundColor: COLORS.dark_gray,
+        },
         textInput: {
           backgroundColor: COLORS.inactive_gray,
           color: 'white',


### PR DESCRIPTION
Fixes the blank space between Google Places Autocomplete results and the keyboard by adjusting container styles and adds error logging.

The blank space was caused by the `GooglePlacesAutocomplete` component inheriting `flex: 1` from its parent, causing it to expand unnecessarily. Setting `flex: 0` on the container and adding a background color to the `listView` resolves this. Error logging was also added for `onFail` events.

---
Linear Issue: [CARPIL-129](https://linear.app/carpil/issue/CARPIL-129/blank-space-between-places-and-keyboard)

<a href="https://cursor.com/background-agent?bcId=bc-e4715881-9c8b-4933-9e85-b7fb9b95d3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4715881-9c8b-4933-9e85-b7fb9b95d3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves UI spacing issue in `GooglePlacesAutocomplete` and adds structured error logging.
> 
> - Wraps `onFail` with `handleFail` to log errors via `logger.error` (includes `action` and `metadata`) before delegating
> - Sets `styles.container` to `flex: 0` to prevent unwanted expansion and adds dark background to `styles.listView`
> - Passes `onFail={handleFail}`; minor style tweaks retained for input/rows
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b3d52c173b594124bcca3981a40da71abcd231a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->