### PR TITLE
Title header overlap fix

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Text, StyleSheet, View, Platform } from 'react-native'
+import { Text, StyleSheet, View } from 'react-native'
 import { CarIcon, MessagesIcon, ProfileIcon } from '@components/icons'
 import { COLORS } from '@utils/constansts/colors'
 import { Tabs } from 'expo-router'
@@ -19,7 +19,7 @@ const HeaderTitle = ({
     <View
       style={{
         backgroundColor: color,
-        paddingTop: (Platform.OS === 'ios' ? insets.top : 0) + 16,
+        paddingTop: insets.top + 16,
         paddingBottom: 10,
         paddingHorizontal: 16,
       }}


### PR DESCRIPTION
Fixes title overlap with native header bar on Android by correctly applying safe area insets to the `HeaderTitle` component.

The previous implementation only applied `insets.top` for iOS, leading to titles being obscured by the status bar on Android. By always applying `insets.top`, the component now respects the status bar height on both platforms.

---
Linear Issue: [CARPIL-145](https://linear.app/carpil/issue/CARPIL-145/title-overlaps-native-header-bar)

<a href="https://cursor.com/background-agent?bcId=bc-9798703b-cfd5-440f-ab81-d6acb587a089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9798703b-cfd5-440f-ab81-d6acb587a089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix header safe-area handling**
> 
> - Always apply `insets.top` in `HeaderTitle` padding (was iOS-only), preventing title overlap with the native status bar on Android
> - Remove unused `Platform` import in `app/(tabs)/_layout.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db68c41430d56266b48c24fe0cb86ddff14309a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->