### PR TITLE
Date time format correction

### DIFF
--- a/utils/format-date.ts
+++ b/utils/format-date.ts
@@ -3,7 +3,7 @@ import { format } from '@formkit/tempo'
 export const formatDate = (dateTime: Date) => {
   const hour = format({
     date: dateTime,
-    format: 'hh:mm a',
+    format: 'hh:mm aa',
     tz: 'America/Costa_Rica',
   })
 


### PR DESCRIPTION
Change time format string from 'hh:mm a' to 'hh:mm aa' to correctly display full 'am/pm' meridiem.

The `@formkit/tempo` library's format token `'a'` outputs a single letter ('a' or 'p'), while `'aa'` outputs the full 'am' or 'pm'.

---
Linear Issue: [CARPIL-137](https://linear.app/carpil/issue/CARPIL-137/missing-m-from-date-736-pm)

<a href="https://cursor.com/background-agent?bcId=bc-734b8769-1bb0-4c11-b535-270940770d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-734b8769-1bb0-4c11-b535-270940770d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures time strings show full meridiem (`am`/`pm`).
> 
> - Update `formatDate` in `utils/format-date.ts` to use `format: 'hh:mm aa'` instead of `'hh:mm a'` when formatting the hour
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1b6a4062e49323d079e21d665f59ecd7c01700. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->