### PR TITLE
Location selection single press

### DIFF
--- a/components/places-autocomplete.tsx
+++ b/components/places-autocomplete.tsx
@@ -69,6 +69,7 @@ export default function PlacesAutocomplete({
       enablePoweredByContainer={false}
       placeholder={placeholder}
       minLength={2}
+      keyboardShouldPersistTaps="handled"
       query={{
         key: GOOGLE_MAPS_API_KEY,
         language: 'es',
@@ -91,6 +92,14 @@ export default function PlacesAutocomplete({
             lng: detail?.geometry.location.lng,
           },
         }
+        logger.info('Location selected from autocomplete', {
+          action: 'location_selected_success',
+          metadata: {
+            placeId: data.place_id,
+            name: data.structured_formatting.main_text,
+            queryType,
+          },
+        })
         onPress(location)
       }}
       onFail={handleFail}


### PR DESCRIPTION
Fixes double-press location selection by adding `keyboardShouldPersistTaps="handled"` and adds logging for successful selections.

The previous behavior required two taps to select a location from Google Place Autocomplete results when the keyboard was active: one to dismiss the keyboard and another to select. This change ensures a single tap selects the location, improving user experience. The added logging helps track successful selections and debug similar issues in the future.

---
Linear Issue: [CARPIL-128](https://linear.app/carpil/issue/CARPIL-128/double-press-to-select-a-location)

<a href="https://cursor.com/background-agent?bcId=bc-431adbc6-e84d-41cf-918b-fb6224ad05f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-431adbc6-e84d-41cf-918b-fb6224ad05f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves selection UX and observability in `components/places-autocomplete.tsx`.
> 
> - Adds `keyboardShouldPersistTaps="handled"` to `GooglePlacesAutocomplete` to allow single-tap selection when the keyboard is open
> - Logs successful selections via `logger.info` in `onPress`, including `placeId`, `name`, and `queryType`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e440bccfc4845393526ca80e329a791a06f776c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->