### PR TITLE
Chat skeleton padding alignment

### DIFF
--- a/components/chats/card.tsx
+++ b/components/chats/card.tsx
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: '#1F2937',
     borderRadius: 8,
-    padding: 12,
+    padding: 16,
     marginBottom: 12,
   },
   date: {

--- a/components/skeletons/chat-card.tsx
+++ b/components/skeletons/chat-card.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: '#1F2937',
     borderRadius: 8,
-    padding: 12,
+    padding: 16,
     marginBottom: 12,
   },
   dateSkeleton: {


### PR DESCRIPTION
Update chat card and skeleton padding to 16px to match application's standard padding and ensure visual symmetry.

---
Linear Issue: [CARPIL-130](https://linear.app/carpil/issue/CARPIL-130/skeletons-are-smaller-than-application-padding-in-chats)

<a href="https://cursor.com/background-agent?bcId=bc-06fe945a-ab4a-4f8c-9ac9-7ba821b4ea3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06fe945a-ab4a-4f8c-9ac9-7ba821b4ea3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes chat item spacing by increasing padding to 16 for both the rendered card and its skeleton.
> 
> - Updates `padding` from `12` to `16` in `components/chats/card.tsx`
> - Updates `padding` from `12` to `16` in `components/skeletons/chat-card.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3275dcebd1cc7e3cf7015773d06f56683da5d275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->