### PR TITLE
Empty chats screen message

### DIFF
--- a/app/chats/index.tsx
+++ b/app/chats/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import { View, StyleSheet, FlatList } from 'react-native'
+import { View, StyleSheet, FlatList, Text } from 'react-native'
+import { useRouter } from 'expo-router'
 import ChatCard from '@components/chats/card'
 import SafeScreen from '@components/safe-screen'
 import { COLORS } from '@utils/constansts/colors'
@@ -7,14 +8,40 @@ import { ChatResponse } from '~types/responses/chat'
 import { getChats } from 'services/api/chats'
 import { useAuthStore } from 'store/useAuthStore'
 import ChatCardSkeleton from '@components/skeletons/chat-card'
+import PrimaryButton from '@components/buttons/primary'
+import { logger } from '@utils/logs'
 
 export default function Chats() {
   const [chats, setChats] = useState<ChatResponse[]>([])
   const { user } = useAuthStore()
   const [loading, setLoading] = useState(true)
+  const router = useRouter()
 
   const renderChat = ({ item }: { item: ChatResponse }) => (
     <ChatCard chat={item} user={user!} />
+  )
+
+  const renderEmpty = () => (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyIcon}>💬</Text>
+      <Text style={styles.emptyTitle}>No tienes chats</Text>
+      <Text style={styles.emptyMessage}>
+        Una vez que te unas a un ride, podrás usar el chat para comunicarte con
+        otros pasajeros y el conductor.
+      </Text>
+      <View style={styles.buttonContainer}>
+        <PrimaryButton
+          text="Buscar un ride"
+          onPress={() => {
+            logger.info('Navigate to create ride from empty chats', {
+              action: 'empty_chats_navigate',
+              metadata: { destination: '/create-ride/select-origin' },
+            })
+            router.push('/create-ride/select-origin')
+          }}
+        />
+      </View>
+    </View>
   )
 
   useEffect(() => {
@@ -23,8 +50,15 @@ export default function Chats() {
         setLoading(true)
         const chats = await getChats()
         setChats(chats)
+        logger.info('Chats fetched successfully', {
+          action: 'fetch_chats_success',
+          metadata: { count: chats.length },
+        })
       } catch (error) {
-        console.error(error)
+        logger.exception(error as Error, {
+          action: 'fetch_chats_error',
+          metadata: { context: 'Failed to fetch chats' },
+        })
       } finally {
         setLoading(false)
       }
@@ -57,6 +91,7 @@ export default function Chats() {
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.listContainer}
           showsVerticalScrollIndicator={false}
+          ListEmptyComponent={renderEmpty}
         />
       </View>
     </SafeScreen>
@@ -78,5 +113,35 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     padding: 16,
+    flexGrow: 1,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 40,
+    paddingVertical: 60,
+  },
+  emptyIcon: {
+    fontSize: 60,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: COLORS.white,
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  emptyMessage: {
+    fontSize: 14,
+    color: COLORS.gray_400,
+    textAlign: 'center',
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+  buttonContainer: {
+    width: '100%',
+    maxWidth: 300,
   },
 })


### PR DESCRIPTION
Add an empty state component to the chats screen to display a friendly message and an action button when no chats are available, improving user experience and adding robust logging.

---
Linear Issue: [CARPIL-122](https://linear.app/carpil/issue/CARPIL-122/empty-screen-after-loading-chats)

<a href="https://cursor.com/background-agent?bcId=bc-8aff02c3-4d55-4fae-a6ed-75de6315b694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8aff02c3-4d55-4fae-a6ed-75de6315b694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an empty state to the chats screen and adds structured logging around chat fetching.
> 
> - Adds an empty state UI in `app/chats/index.tsx` with emoji, message, and a `PrimaryButton` to "Buscar un ride"
> - Navigates to `/create-ride/select-origin` via `useRouter` when the button is pressed, with `logger.info` telemetry
> - Replaces error `console.error` with `logger.exception` and adds success logging after `getChats()`
> - Uses `FlatList` `ListEmptyComponent` to render the empty state; adds `flexGrow` and new empty state styles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93626dd1866678b36163b0f69a945a493f419198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->