### PR TITLE
Location icon alignment fix

### DIFF
--- a/components/places-autocomplete.tsx
+++ b/components/places-autocomplete.tsx
@@ -94,6 +94,7 @@ export default function PlacesAutocomplete({
         onPress(location)
       }}
       onFail={handleFail}
+      renderRightButton={() => null}
       styles={{
         container: {
           flex: 0,
@@ -111,6 +112,9 @@ export default function PlacesAutocomplete({
         },
         separator: {
           height: 0,
+        },
+        loader: {
+          display: 'none',
         },
       }}
       textInputProps={{


### PR DESCRIPTION
Remove the unnecessary and misaligned loading indicator from the GooglePlacesAutocomplete component to improve user experience.

The `GooglePlacesAutocomplete` component's default behavior includes a loading indicator while fetching place details, which caused an alignment issue. This PR hides it using `renderRightButton={() => null}` and an additional `loader: { display: 'none' }` style.

---
Linear Issue: [CARPIL-133](https://linear.app/carpil/issue/CARPIL-133/not-aligned-loading-icon-after-selecting-location)

<a href="https://cursor.com/background-agent?bcId=bc-10be71b2-c7e2-4430-9fe9-a7a97e5d8aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10be71b2-c7e2-4430-9fe9-a7a97e5d8aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the misaligned loading indicator in `GooglePlacesAutocomplete` to fix UI alignment without altering behavior.
> 
> - In `components/places-autocomplete.tsx`, disables the right-side loader via `renderRightButton={() => null}` and hides it with `styles.loader: { display: 'none' }`
> - No changes to autocomplete logic; this is a visual-only tweak
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad9a4bdfec84bb6da3d723637441094c6ffbb174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->