### PR TITLE
Empty chat message display

### DIFF
--- a/app/chats/[chatId].tsx
+++ b/app/chats/[chatId].tsx
@@ -29,6 +29,7 @@ import { FirestoreMessage, MessageBubble } from '~types/message'
 import { useAuthStore } from 'store/useAuthStore'
 import { decryptMessage } from '@utils/decrypt-message'
 import MessageBubbleComponent from '@components/chats/message-bubble'
+import { logger } from '@utils/logs'
 
 export default function Messages() {
   const [chat, setChat] = useState<ChatResponse | null>(null)
@@ -118,9 +119,17 @@ export default function Messages() {
               return message
             }),
           )
-          setMessages(
-            newMessages.filter((msg): msg is MessageBubble => msg !== null),
+          const filteredMessages = newMessages.filter(
+            (msg): msg is MessageBubble => msg !== null,
           )
+          setMessages(filteredMessages)
+
+          if (filteredMessages.length === 0) {
+            logger.info('Chat has no messages yet', {
+              action: 'chat_empty_state_shown',
+              metadata: { chatId: chatId as string },
+            })
+          }
         })
 
         return unsubscribe
@@ -186,15 +195,23 @@ export default function Messages() {
       <View style={styles.container}>
         {/* messages */}
         <View style={styles.messagesContainer}>
-          {messages.map((message) => (
-            <MessageBubbleComponent
-              key={message.id}
-              user={message.user}
-              message={message.content}
-              isDriver={message.isMe}
-              createdAt={message.createdAt}
-            />
-          ))}
+          {messages.length === 0 ? (
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyIcon}>💬</Text>
+              <Text style={styles.emptyTitle}>Aún no hay mensajes</Text>
+              <Text style={styles.emptySubtitle}>Inicia la conversación</Text>
+            </View>
+          ) : (
+            messages.map((message) => (
+              <MessageBubbleComponent
+                key={message.id}
+                user={message.user}
+                message={message.content}
+                isDriver={message.isMe}
+                createdAt={message.createdAt}
+              />
+            ))
+          )}
         </View>
         <View style={styles.inputContainer}>
           <TextInput
@@ -316,6 +333,28 @@ const styles = StyleSheet.create({
     color: COLORS.gray_400,
     textAlign: 'center',
     marginTop: 10,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 40,
+  },
+  emptyIcon: {
+    fontSize: 50,
+    marginBottom: 10,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    color: COLORS.white,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: COLORS.gray_400,
+    textAlign: 'center',
+    marginTop: 8,
   },
 })
 


### PR DESCRIPTION
Add an empty state message to chat screens when no messages are present to improve user experience.

---
Linear Issue: [CARPIL-112](https://linear.app/carpil/issue/CARPIL-112/empty-messages-for-chatsmessages)

<a href="https://cursor.com/background-agent?bcId=bc-4287ae82-0525-4188-bfea-057101440faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4287ae82-0525-4188-bfea-057101440faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an empty-state UX for chats with basic telemetry and a small refactor around message processing.
> 
> - Adds conditional rendering in `app/chats/[chatId].tsx` to show an empty state (icon/title/subtitle) when `messages.length === 0`
> - Imports `logger` and logs `chat_empty_state_shown` when a chat has no messages
> - Refactors snapshot handling to create `filteredMessages` before `setMessages`
> - Adds styles for the new empty-state UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b29dbf36140279b7fa2bae7bb7389cf075ce5443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->