### PR TITLE
Chat message sending failure

### DIFF
--- a/services/api/chats.ts
+++ b/services/api/chats.ts
@@ -2,6 +2,7 @@ import { API_URL } from '@utils/constansts/api'
 import { useAuthStore } from 'store/useAuthStore'
 import { ChatResponse } from '~types/responses/chat'
 import { logger } from '@utils/logs'
+import { encryptMessage } from '@utils/decrypt-message'
 
 export const getChats = async () => {
   const token = useAuthStore.getState().token
@@ -65,13 +66,15 @@ export const getChat = async (id: string) => {
 
 export const sendMessage = async (chatId: string, message: string) => {
   const token = useAuthStore.getState().token
+  const encryptedMessage = encryptMessage(message)
+  
   const response = await fetch(`${API_URL}/chats/${chatId}/messages`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ content: message }),
+    body: JSON.stringify({ content: encryptedMessage }),
   })
 
   if (!response.ok) {

--- a/utils/decrypt-message.ts
+++ b/utils/decrypt-message.ts
@@ -2,6 +2,16 @@ import CryptoJS from 'crypto-js'
 
 const secretKey = process.env.EXPO_PUBLIC_CHAT_SECRET_KEY ?? ''
 
+export const encryptMessage = (plaintext: string): string => {
+  try {
+    const encrypted = CryptoJS.AES.encrypt(plaintext, secretKey)
+    return encrypted.toString()
+  } catch (error) {
+    console.error('Error encrypting message:', error)
+    return plaintext
+  }
+}
+
 export const decryptMessage = (ciphertext: string): string => {
   try {
     const bytes = CryptoJS.AES.decrypt(ciphertext, secretKey)


### PR DESCRIPTION
Encrypt chat messages before sending to match backend requirements and improve error logging.

Messages were failing to send because the frontend was transmitting them in plain text, while the backend expected AES-encrypted content. This PR introduces an encryption utility and applies it to outgoing messages, along with enhanced error logging for better diagnostics.

---
Linear Issue: [CARPIL-123](https://linear.app/carpil/issue/CARPIL-123/not-sending-or-receiving-messages-from-chat)

<a href="https://cursor.com/background-agent?bcId=bc-15152b2c-f1ef-42bc-a08a-55ccb2414d06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15152b2c-f1ef-42bc-a08a-55ccb2414d06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

